### PR TITLE
Added references override params for APS beamlines. Fixed it so that …

### DIFF
--- a/reference/override_parameters/2ide-maps_fit_parameters_override.txt
+++ b/reference/override_parameters/2ide-maps_fit_parameters_override.txt
@@ -1,0 +1,175 @@
+   This file will override default fit settings for the maps program for a 3 element detector remove: removeme_*elementdetector_to make it work. 
+   note, the filename MUST be maps_fit_parameters_override.txt
+VERSION: 5.0
+DATE: 2015-11-04 15:32:58.832000
+   put below the number of detectors that were used to acquire spectra. IMPORTANT:
+   this MUST come after VERSION, and before all other options!
+DETECTOR_ELEMENTS: 1
+   give this file an internal name, whatever you like
+IDENTIFYING_NAME_[WHATEVERE_YOU_LIKE]: automatic
+   list the elements that you want to be fit. For K lines, just use the element
+   name, for L lines add _L, e.g., Au_L, for M lines add _M
+ELEMENTS_TO_FIT: Si, P, S, Cl, Ar, K, Ca, Ti, Cr, Mn, Fe, Co, Ni, Cu, Zn
+   list the element combinations you want to fit for pileup, e.g., Si_Si, Si_Si_Si, Si_Cl, etc
+ELEMENTS_WITH_PILEUP: 
+   offset of energy calibration, in kev
+CAL_OFFSET_[E_OFFSET]: -0.0041840752
+CAL_OFFSET_[E_OFFSET]_MAX: 0.5
+CAL_OFFSET_[E_OFFSET]_MIN: -0.5
+   slope of energy calibration, in leV / channel
+CAL_SLOPE_[E_LINEAR]: 0.0095216077
+CAL_SLOPE_[E_LINEAR]_MAX: 0.015
+CAL_SLOPE_[E_LINEAR]_MIN: 0.0079999994
+   quadratic correction for energy calibration, unless you know exactly what you are doing, please leave it at 0.
+CAL_QUAD_[E_QUADRATIC]: 0.0
+CAL_QUAD_[E_QUADRATIC]_MAX: 9.9999997e-05
+CAL_QUAD_[E_QUADRATIC]_MIN: -9.9999997e-05
+    energy_resolution at 0keV
+FWHM_OFFSET: 0.09721764
+    energy dependence of the energy resolution
+FWHM_FANOPRIME: 0.00022440446
+    incident energy
+COHERENT_SCT_ENERGY: 10.0
+    upper constraint for the incident energy
+COHERENT_SCT_ENERGY_MAX: 10.599999
+    lower constraint for the incident energy
+COHERENT_SCT_ENERGY_MIN: 9.699999
+    angle for the compton scatter (in degrees)
+COMPTON_ANGLE: 87.274598
+COMPTON_ANGLE_MAX: 170.0
+COMPTON_ANGLE_MIN: 70.0
+    additional width of the compton
+COMPTON_FWHM_CORR: 1.5730172
+COMPTON_STEP: 0.0
+COMPTON_F_TAIL: 0.13308163
+COMPTON_GAMMA: 3.0
+COMPTON_HI_F_TAIL: 0.0039171793
+COMPTON_HI_GAMMA: 3.0
+    tailing parameters, see also Grieken, Markowicz, Handbook of X-ray spectrometry
+    2nd ed, van Espen spectrum evaluation page 287.	_A corresponds to f_S, _B to
+    f_T and _C to gamma
+STEP_OFFSET: 0.0
+STEP_LINEAR: 0.0
+STEP_QUADRATIC: 0.0
+F_TAIL_OFFSET: 0.003
+F_TAIL_LINEAR: 1.6940659e-21
+F_TAIL_QUADRATIC: 0.0
+KB_F_TAIL_OFFSET: 0.05
+KB_F_TAIL_LINEAR: 0.0
+KB_F_TAIL_QUADRATIC: 0.0
+GAMMA_OFFSET: 2.2101209
+GAMMA_LINEAR: 0.0
+GAMMA_QUADRATIC: 0.0
+    snip width is the width used for estimating background. 0.5 is typically a good start 
+SNIP_WIDTH: 0.5
+    set FIT_SNIP_WIDTH to 1 to fit the width of the snipping for background estimate, set to 0 not to. Only use if you know what it is doing!
+FIT_SNIP_WIDTH: 0
+    detector material: 0= Germanium, 1 = Si
+DETECTOR_MATERIAL: 1
+    beryllium window thickness, in micrometers, typically 8 or 24
+BE_WINDOW_THICKNESS: 0.0
+thickness of the detector chip, e.g., 350 microns for an SDD
+DET_CHIP_THICKNESS: 0.0
+thickness of the Germanium detector dead layer, in microns, for the purposes of the NBS calibration
+GE_DEAD_LAYER: 0.0
+    maximum energy value to fit up to [keV]
+MAX_ENERGY_TO_FIT: 11.0
+    minimum energy value [keV]
+MIN_ENERGY_TO_FIT: 1.0
+    this allows manual adjustment of the branhcing ratios between the different lines of L1, L2, and L3.
+    note, the numbers that are put in should be RELATIVE modifications, i.e., a 1 will correspond to exactly the literature value,
+    0.8 will correspond to to 80% of that, etc.
+BRANCHING_FAMILY_ADJUSTMENT_L: Pt_L, 0., 1., 1.
+BRANCHING_FAMILY_ADJUSTMENT_L: Gd_L, 1., 1., 1.
+BRANCHING_FAMILY_ADJUSTMENT_L: Sn_L, 0., 0., 1.
+BRANCHING_FAMILY_ADJUSTMENT_L: I_L, 1., 1., 1.
+    this allows manual adjustment of the branhcing ratios between the different L lines, such as La 1, la2, etc.
+    Please note, these are all RELATIVE RELATIVE modifications, i.e., a 1 will correspond to exactly the literature value, etc.
+    all will be normalized to the La1 line, and the values need to be in the following order:
+    La1, La2, Lb1, Lb2, Lb3, Lb4, Lg1, Lg2, Lg3, Lg4, Ll, Ln
+    please note, the first value (la1) MUST BE A 1. !!!
+BRANCHING_RATIO_ADJUSTMENT_L: Pb_L, 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.
+BRANCHING_RATIO_ADJUSTMENT_L: I_L, 1., 1., 0.45, 1.0, 0.45, 0.45, 0.6, 1., 0.3, 1., 1., 1.
+BRANCHING_RATIO_ADJUSTMENT_L: Gd_L, 1., 0.48, 0.59, 0.98, 0.31, 0.08, 0.636, 1., 0.3, 1., 1., 1.
+BRANCHING_RATIO_ADJUSTMENT_L: Sn_L, 1., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.
+    this allows manual adjustment of the branhcing ratios between the different K lines, such as Ka1, Ka2, Kb1, Kb2
+    Please note, these are all RELATIVE RELATIVE modifications, i.e., a 1 will correspond to exactly the literature value, etc.
+    all will be normalized to the Ka1 line, and the values need to be in the following order:
+    Ka1, Ka2, Kb1(+3), Kb2
+    please note, the first value (Ka1) MUST BE A 1. !!!
+BRANCHING_RATIO_ADJUSTMENT_K: Na, 1., 1., 4.0, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: Mg, 1., 1., 3.6, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: Al, 1., 1., 3.3, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: Si, 1., 1., 2.9, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: P, 1., 1., 2.75, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: S, 1., 1., 2.6, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: Cl, 1., 1., 2.5, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: Ar, 1., 1., 2.2, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: K, 1., 1., 1.9, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: Ca, 1., 1., 1.7, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: Ti, 1., 1., 1.6, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: V, 1., 1., 1.4, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: Cr, 1., 1., 1.35, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: Mn, 1., 1., 1.3, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: Fe, 1., 1., 1.2, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: Co, 1., 1., 1.1, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: Ni, 1., 1., 1.05, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: Cu, 1., 1., 1.0, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: Zn, 1., 1., 1.0, 1.
+    the parameter adds the escape peaks (offset) to the fit if larger than 0. You should not enable Si and Ge at the same time, ie, one of these two values should be zero
+SI_ESCAPE_FACTOR: 0.0
+GE_ESCAPE_FACTOR: 0.0
+    this parameter adds a component to the escape peak that depends linear on energy
+LINEAR_ESCAPE_FACTOR: 0.0
+    the parameter enables fitting of the escape peak strengths. set 1 to enable, set to 0 to disable. (in matrix fitting always disabled)
+SI_ESCAPE_ENABLE: 0
+GE_ESCAPE_ENABLE: 0
+    the lines (if any) below will override the detector names built in to maps. please modify only if you are sure you understand the effect
+SRCURRENT: S:SRcurrentAI
+US_IC: 2xfm:scaler3_cts1.B
+DS_IC: 2xfm:scaler3_cts1.C
+DPC1_IC: 2xfm:scaler3_cts2.A
+DPC2_IC: 2xfm:scaler3_cts2.B
+CFG_1: 2xfm:scaler3_cts3.B
+CFG_2: 2xfm:scaler3_cts3.C
+CFG_3: 2xfm:scaler3_cts3.D
+CFG_4: 2xfm:scaler3_cts4.A
+CFG_5: 2xfm:scaler3_cts4.B
+CFG_6: 2xfm:scaler3_cts4.C
+CFG_7: 2xfm:scaler3_cts4.D
+CFG_8: 2xfm:scaler3_cts5.A
+CFG_9: 2xfm:scaler3_cts5.B
+    These scalers are for fly scans.  Tag: Name;PV
+TIME_SCALER_PV: 2xfm:mcs:mca1.VAL
+TIME_SCALER_CLOCK: 25000000.0
+TIME_NORMALIZED_SCALER: US_IC;2xfm:mcs:mca2.VAL
+TIME_NORMALIZED_SCALER: DS_IC;2xfm:mcs:mca3.VAL
+TIME_NORMALIZED_SCALER: DPC1_IC;2xfm:mcs:mca5.VAL
+TIME_NORMALIZED_SCALER: DPC2_IC;2xfm:mcs:mca6.VAL
+TIME_NORMALIZED_SCALER: CFG_1;2xfm:mcs:mca10.VAL
+TIME_NORMALIZED_SCALER: CFG_2;2xfm:mcs:mca11.VAL
+TIME_NORMALIZED_SCALER: CFG_3;2xfm:mcs:mca12.VAL
+TIME_NORMALIZED_SCALER: CFG_4;2xfm:mcs:mca13.VAL
+TIME_NORMALIZED_SCALER: CFG_5;2xfm:mcs:mca14.VAL
+TIME_NORMALIZED_SCALER: CFG_6;2xfm:mcs:mca15.VAL
+TIME_NORMALIZED_SCALER: CFG_7;2xfm:mcs:mca16.VAL
+TIME_NORMALIZED_SCALER: CFG_8;2xfm:mcs:mca17.VAL
+TIME_NORMALIZED_SCALER: CFG_9;2xfm:mcs:mca18.VAL
+    Spectra scalers
+ELT1: dxpXMAP2xfm3:mca1.ELTM
+ERT1: dxpXMAP2xfm3:mca1.ERTM
+ICR1: dxpXMAP2xfm3:dxp1:InputCountRate
+OCR1: dxpXMAP2xfm3:dxp1:OutputCountRate
+    the lines below (if any) give backup description of IC amplifier sensitivity, in case it cannot be found in the mda file
+		 for the amps, the _NUM value should be between 0 and 8 where 0=1, 1=2, 2=5, 3=10, 4=20, 5=50, 6=100, 7=200, 8=500
+		 for the amps, the _UNIT value should be between 0 and 3 where 0=pa/v, 1=na/v, 2=ua/v 3=ma/v
+    search for the PV first, if not found then use the values below
+US_AMP_SENS_NUM_PV: 2xfm:A1sens_num.VAL
+US_AMP_SENS_UNIT_PV: 2xfm:A1sens_unit.VAL
+DS_AMP_SENS_NUM_PV: 2xfm:A2sens_num.VAL
+DS_AMP_SENS_UNIT_PV: 2xfm:A2sens_unit.VAL
+
+US_AMP_SENS_NUM:        5
+US_AMP_SENS_UNIT:        1
+DS_AMP_SENS_NUM:        1
+DS_AMP_SENS_UNIT:        1

--- a/reference/override_parameters/8bmb-maps_fit_parameters_override.txt
+++ b/reference/override_parameters/8bmb-maps_fit_parameters_override.txt
@@ -1,0 +1,153 @@
+   This file will override default fit settings for the maps program for a 3 element detector remove: removeme_*elementdetector_to make it work. 
+   note, the filename MUST be maps_fit_parameters_override.txt
+VERSION: 5.0
+DATE: 2015-09-25 21:28:04.312000
+   put below the number of detectors that were used to acquire spectra. IMPORTANT:
+   this MUST come after VERSION, and before all other options!
+DETECTOR_ELEMENTS: 1
+   give this file an internal name, whatever you like
+IDENTIFYING_NAME_[WHATEVERE_YOU_LIKE]: automatic
+   list the elements that you want to be fit. For K lines, just use the element
+   name, for L lines add _L, e.g., Au_L, for M lines add _M
+ELEMENTS_TO_FIT: Si, P, S, Cl, Ar, K, Ca, Ti, Cr, Mn, Fe, Ni, Co, Cu, Zn, Au_L
+   list the element combinations you want to fit for pileup, e.g., Si_Si_Si, Si_Cl, etc
+ELEMENTS_WITH_PILEUP: 
+   offset of energy calibration, in kev
+CAL_OFFSET_[E_OFFSET]: 0.028137284
+CAL_OFFSET_[E_OFFSET]_MAX: 0.050000001
+CAL_OFFSET_[E_OFFSET]_MIN: -0.050000001
+   slope of energy calibration, in leV / channel
+CAL_SLOPE_[E_LINEAR]: 0.0115
+CAL_SLOPE_[E_LINEAR]_MAX: 0.013
+CAL_SLOPE_[E_LINEAR]_MIN: 0.01
+   quadratic correction for energy calibration, unless you know exactly what you are doing, please leave it at 0.
+CAL_QUAD_[E_QUADRATIC]: 0.0
+CAL_QUAD_[E_QUADRATIC]_MAX: 9.9999997e-05
+CAL_QUAD_[E_QUADRATIC]_MIN: -9.9999997e-05
+    energy_resolution at 0keV
+FWHM_OFFSET: 0.01
+    energy dependence of the energy resolution
+FWHM_FANOPRIME: 0.00065712239
+    incident energy
+COHERENT_SCT_ENERGY: 15.01
+    upper constraint for the incident energy
+COHERENT_SCT_ENERGY_MAX: 15.3
+    lower constraint for the incident energy
+COHERENT_SCT_ENERGY_MIN: 14.7
+    angle for the compton scatter (in degrees)
+COMPTON_ANGLE: 91.575496
+COMPTON_ANGLE_MAX: 170.0
+COMPTON_ANGLE_MIN: 70.0
+    additional width of the compton
+COMPTON_FWHM_CORR: 1.9860346
+COMPTON_STEP: 0.0
+COMPTON_F_TAIL: 0.039961524
+COMPTON_GAMMA: 3.0
+COMPTON_HI_F_TAIL: 0.78938302
+COMPTON_HI_GAMMA: 3.0
+    tailing parameters, see also Grieken, Markowicz, Handbook of X-ray spectrometry
+    2nd ed, van Espen spectrum evaluation page 287.	_A corresponds to f_S, _B to
+    f_T and _C to gamma
+STEP_OFFSET: 0.0
+STEP_LINEAR: 0.0
+STEP_QUADRATIC: 0.0
+F_TAIL_OFFSET: 0.035931118
+F_TAIL_LINEAR: 1.6940659e-21
+F_TAIL_QUADRATIC: 0.0
+KB_F_TAIL_OFFSET: 0.16684721
+KB_F_TAIL_LINEAR: 0.0
+KB_F_TAIL_QUADRATIC: 0.0
+GAMMA_OFFSET: 2.2101209
+GAMMA_LINEAR: 0.0
+GAMMA_QUADRATIC: 0.0
+    snip width is the width used for estimating background. 0.5 is typically a good start 
+SNIP_WIDTH: 0.5
+    set FIT_SNIP_WIDTH to 1 to fit the width of the snipping for background estimate, set to 0 not to. Only use if you know what it is doing!
+FIT_SNIP_WIDTH: 0
+    detector material: 0= Germanium, 1 = Si
+DETECTOR_MATERIAL: 1
+    beryllium window thickness, in micrometers, typically 8 or 24
+BE_WINDOW_THICKNESS: 24.0
+thickness of the detector chip, e.g., 350 microns for an SDD
+DET_CHIP_THICKNESS: 0.0
+thickness of the Germanium detector dead layer, in microns, for the purposes of the NBS calibration
+GE_DEAD_LAYER: 0.0
+    maximum energy value to fit up to [keV]
+MAX_ENERGY_TO_FIT: 15.5
+    minimum energy value [keV]
+MIN_ENERGY_TO_FIT: 1.0
+    this allows manual adjustment of the branhcing ratios between the different lines of L1, L2, and L3.
+    note, the numbers that are put in should be RELATIVE modifications, i.e., a 1 will correspond to exactly the literature value,
+    0.8 will correspond to to 80% of that, etc.
+BRANCHING_FAMILY_ADJUSTMENT_L: Pb_L, 0., 0., 1.
+BRANCHING_FAMILY_ADJUSTMENT_L: Hg_L, 0., 0., 1.
+BRANCHING_FAMILY_ADJUSTMENT_L: Pt_L, 1., 1., 1.
+BRANCHING_FAMILY_ADJUSTMENT_L: Au_L, 1., 1., 1.
+BRANCHING_FAMILY_ADJUSTMENT_L: Gd_L, 1., 1., 1.
+BRANCHING_FAMILY_ADJUSTMENT_L: Sn_L, 1., 1., 1.
+BRANCHING_FAMILY_ADJUSTMENT_L: Zr_L, 1., 1., 1.
+BRANCHING_FAMILY_ADJUSTMENT_L: Pu_L, 0., 0., 1.
+BRANCHING_FAMILY_ADJUSTMENT_L: I_L, 1., 1., 1.
+    this allows manual adjustment of the branhcing ratios between the different L lines, such as La 1, la2, etc.
+    Please note, these are all RELATIVE RELATIVE modifications, i.e., a 1 will correspond to exactly the literature value, etc.
+    all will be normalized to the La1 line, and the values need to be in the following order:
+    La1, La2, Lb1, Lb2, Lb3, Lb4, Lg1, Lg2, Lg3, Lg4, Ll, Ln
+    please note, the first value (la1) MUST BE A 1. !!!
+BRANCHING_RATIO_ADJUSTMENT_L: Pb_L, 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.
+BRANCHING_RATIO_ADJUSTMENT_L: I_L, 1., 1., 0.45, 1.0, 0.45, 0.45, 0.6, 1., 0.3, 1., 1., 1.
+BRANCHING_RATIO_ADJUSTMENT_L: Gd_L, 1., 0.48, 0.59, 0.98, 0.31, 0.08, 0.636, 1., 0.3, 1., 1., 1.
+BRANCHING_RATIO_ADJUSTMENT_L: Sn_L, 1., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.
+    this allows manual adjustment of the branhcing ratios between the different K lines, such as Ka1, Ka2, Kb1, Kb2
+    Please note, these are all RELATIVE RELATIVE modifications, i.e., a 1 will correspond to exactly the literature value, etc.
+    all will be normalized to the Ka1 line, and the values need to be in the following order:
+    Ka1, Ka2, Kb1(+3), Kb2
+    please note, the first value (Ka1) MUST BE A 1. !!!
+BRANCHING_RATIO_ADJUSTMENT_K: Na, 1., 1., 4.0, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: Mg, 1., 1., 3.6, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: Al, 1., 1., 3.3, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: Si, 1., 1., 2.9, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: P, 1., 1., 2.75, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: S, 1., 1., 2.6, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: Cl, 1., 1., 2.5, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: Ar, 1., 1., 2.2, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: K, 1., 1., 1.9, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: Ca, 1., 1., 1.7, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: Ti, 1., 1., 1.6, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: V, 1., 1., 1.4, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: Cr, 1., 1., 1.35, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: Mn, 1., 1., 1.3, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: Fe, 1., 1., 1.2, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: Co, 1., 1., 1.1, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: Ni, 1., 1., 1.05, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: Cu, 1., 1., 1.0, 1.
+BRANCHING_RATIO_ADJUSTMENT_K: Zn, 1., 1., 1.0, 1.
+    the parameter adds the escape peaks (offset) to the fit if larger than 0. You should not enable Si and Ge at the same time, ie, one of these two values should be zero
+SI_ESCAPE_FACTOR: 0.000
+GE_ESCAPE_FACTOR: 0.0
+    this parameter adds a component to the escape peak that depends linear on energy
+LINEAR_ESCAPE_FACTOR: 0.0
+    the parameter enables fitting of the escape peak strengths. set 1 to enable, set to 0 to disable. (in matrix fitting always disabled)
+SI_ESCAPE_ENABLE: 0
+GE_ESCAPE_ENABLE: 0
+    the lines (if any) below will override the detector names built in to maps. please modify only if you are sure you understand the effect
+SRCURRENT: S:SRcurrentAI
+US_IC: 8bmb:3820:scaler1_cts1.B
+DS_IC: 8bmb:3820:scaler1_cts1.C
+    These scalers are for fly scans.  Tag: Name;PV
+TIME_SCALER_PV: 8bmb:3820:mca1.VAL
+TIME_SCALER_CLOCK: 50000000.0
+TIME_NORMALIZED_SCALER: US_IC;8bmb:3820:mca2.VAL
+TIME_NORMALIZED_SCALER: DS_IC;8bmb:3820:mca3.VAL
+    Spectra scalers
+ELT1:dxpXMAPDP3:mca<detector+1>.ELTM
+ERT1:dxpXMAPDP3:mca<detector+1>1.ERTM
+ICR1:dxpXMAPDP3:dxp<detector+1>:InputCountRate
+OCR1:dxpXMAPDP3:dxp<detector+1>:OutputCountRate
+AIRPATH: 1000.
+    the lines below (if any) give backup description of IC amplifier sensitivity, in case it cannot be found in the mda file
+		 for the amps, the _NUM value should be between 0 and 8 where 0=1, 1=2, 2=5, 3=10, 4=20, 5=50, 6=100, 7=200, 8=500
+		 for the amps, the _UNIT value should be between 0 and 3 where 0=pa/v, 1=na/v, 2=ua/v 3=ma/v
+US_AMP_SENS_NUM:0
+US_AMP_SENS_UNIT:1
+DS_AMP_SENS_NUM:0
+DS_AMP_SENS_UNIT:1

--- a/reference/override_parameters/9idb-maps_fit_parameters_override.txt
+++ b/reference/override_parameters/9idb-maps_fit_parameters_override.txt
@@ -1,88 +1,88 @@
    This file will override default fit settings for the maps program for a 3 element detector remove: removeme_*elementdetector_to make it work. 
    note, the filename MUST be maps_fit_parameters_override.txt
-VERSION: 5.0
-DATE: 2015-11-04 15:32:58.832000
+VERSION:      5.00000
+DATE:Fri Mar 22 16:03:49 2019
    put below the number of detectors that were used to acquire spectra. IMPORTANT:
    this MUST come after VERSION, and before all other options!
-DETECTOR_ELEMENTS: 1
+DETECTOR_ELEMENTS:       1
    give this file an internal name, whatever you like
-IDENTIFYING_NAME_[WHATEVERE_YOU_LIKE]: automatic
+IDENTIFYING_NAME_[WHATEVERE_YOU_LIKE]:automatic
    list the elements that you want to be fit. For K lines, just use the element
    name, for L lines add _L, e.g., Au_L, for M lines add _M
-ELEMENTS_TO_FIT: Si, P, S, Cl, Ar, K, Ca, Ti, Cr, Mn, Fe, Co, Ni, Cu, Zn
+ELEMENTS_TO_FIT: Al, Si, P, S, Cl, K, Ca, Ti, Cr, Mn, Fe, Ni, Co, Cu, Zn, Y_L
    list the element combinations you want to fit for pileup, e.g., Si_Si, Si_Si_Si, Si_Cl, etc
-ELEMENTS_WITH_PILEUP: 
+ELEMENTS_WITH_PILEUP: Si_Si, Cl_Cl, Si_Cl
    offset of energy calibration, in kev
-CAL_OFFSET_[E_OFFSET]: -0.0041840752
-CAL_OFFSET_[E_OFFSET]_MAX: 0.5
-CAL_OFFSET_[E_OFFSET]_MIN: -0.5
+CAL_OFFSET_[E_OFFSET]:    -0.025876192
+CAL_OFFSET_[E_OFFSET]_MAX:      0.50000000
+CAL_OFFSET_[E_OFFSET]_MIN:     -0.50000000
    slope of energy calibration, in leV / channel
-CAL_SLOPE_[E_LINEAR]: 0.0095216077
-CAL_SLOPE_[E_LINEAR]_MAX: 0.015
-CAL_SLOPE_[E_LINEAR]_MIN: 0.0079999994
+CAL_SLOPE_[E_LINEAR]:     0.012749693
+CAL_SLOPE_[E_LINEAR]_MAX:     0.015000000
+CAL_SLOPE_[E_LINEAR]_MIN:    0.0079999994
    quadratic correction for energy calibration, unless you know exactly what you are doing, please leave it at 0.
-CAL_QUAD_[E_QUADRATIC]: 0.0
-CAL_QUAD_[E_QUADRATIC]_MAX: 9.9999997e-05
-CAL_QUAD_[E_QUADRATIC]_MIN: -9.9999997e-05
+CAL_QUAD_[E_QUADRATIC]:      0.00000000
+CAL_QUAD_[E_QUADRATIC]_MAX:  9.9999997e-005
+CAL_QUAD_[E_QUADRATIC]_MIN: -9.9999997e-005
     energy_resolution at 0keV
-FWHM_OFFSET: 0.09721764
+FWHM_OFFSET:      0.12400775
     energy dependence of the energy resolution
-FWHM_FANOPRIME: 0.00022440446
+FWHM_FANOPRIME:   0.00016990854
     incident energy
-COHERENT_SCT_ENERGY: 10.0
-    upper constraint for the incident energy
-COHERENT_SCT_ENERGY_MAX: 10.599999
-    lower constraint for the incident energy
-COHERENT_SCT_ENERGY_MIN: 9.699999
+COHERENT_SCT_ENERGY:       9.9925238
+    upper contstraint for the incident energy
+COHERENT_SCT_ENERGY_MAX:       10.300000
+    lower contstraint for the incident energy
+COHERENT_SCT_ENERGY_MIN:       9.6999998
     angle for the compton scatter (in degrees)
-COMPTON_ANGLE: 87.274598
-COMPTON_ANGLE_MAX: 170.0
-COMPTON_ANGLE_MIN: 70.0
+COMPTON_ANGLE:       86.257156
+COMPTON_ANGLE_MAX:       170.00000
+COMPTON_ANGLE_MIN:       70.000000
     additional width of the compton
-COMPTON_FWHM_CORR: 1.5730172
-COMPTON_STEP: 0.0
-COMPTON_F_TAIL: 0.13308163
-COMPTON_GAMMA: 3.0
-COMPTON_HI_F_TAIL: 0.0039171793
-COMPTON_HI_GAMMA: 3.0
+COMPTON_FWHM_CORR:       1.1696493
+COMPTON_STEP:      0.00000000
+COMPTON_F_TAIL:      0.27625999
+COMPTON_GAMMA:       3.0000000
+COMPTON_HI_F_TAIL:    0.0075764819
+COMPTON_HI_GAMMA:       3.0000000
     tailing parameters, see also Grieken, Markowicz, Handbook of X-ray spectrometry
-    2nd ed, van Espen spectrum evaluation page 287.	_A corresponds to f_S, _B to
+    2nd ed, van Espen spectrum evaluation page 287.  _A corresponds to f_S, _B to
     f_T and _C to gamma
-STEP_OFFSET: 0.0
-STEP_LINEAR: 0.0
-STEP_QUADRATIC: 0.0
-F_TAIL_OFFSET: 0.003
-F_TAIL_LINEAR: 1.6940659e-21
-F_TAIL_QUADRATIC: 0.0
-KB_F_TAIL_OFFSET: 0.05
-KB_F_TAIL_LINEAR: 0.0
-KB_F_TAIL_QUADRATIC: 0.0
-GAMMA_OFFSET: 2.2101209
-GAMMA_LINEAR: 0.0
-GAMMA_QUADRATIC: 0.0
+STEP_OFFSET:      0.00000000
+STEP_LINEAR:      0.00000000
+STEP_QUADRATIC:      0.00000000
+F_TAIL_OFFSET:     0.035931118
+F_TAIL_LINEAR:  1.6940659e-021
+F_TAIL_QUADRATIC:      0.00000000
+KB_F_TAIL_OFFSET:      0.16684721
+KB_F_TAIL_LINEAR:      0.00000000
+KB_F_TAIL_QUADRATIC:      0.00000000
+GAMMA_OFFSET:       2.2101209
+GAMMA_LINEAR:      0.00000000
+GAMMA_QUADRATIC:      0.00000000
     snip width is the width used for estimating background. 0.5 is typically a good start 
-SNIP_WIDTH: 0.5
+SNIP_WIDTH:      0.50000000
     set FIT_SNIP_WIDTH to 1 to fit the width of the snipping for background estimate, set to 0 not to. Only use if you know what it is doing!
-FIT_SNIP_WIDTH: 0
+FIT_SNIP_WIDTH:       0
     detector material: 0= Germanium, 1 = Si
-DETECTOR_MATERIAL: 1
+DETECTOR_MATERIAL:   1
     beryllium window thickness, in micrometers, typically 8 or 24
-BE_WINDOW_THICKNESS: 0.0
+BE_WINDOW_THICKNESS:       24.000000
 thickness of the detector chip, e.g., 350 microns for an SDD
-DET_CHIP_THICKNESS: 0.0
+DET_CHIP_THICKNESS:       350.00000
 thickness of the Germanium detector dead layer, in microns, for the purposes of the NBS calibration
-GE_DEAD_LAYER: 0.0
+GE_DEAD_LAYER:      0.00000000
     maximum energy value to fit up to [keV]
-MAX_ENERGY_TO_FIT: 11.0
+MAX_ENERGY_TO_FIT:       12.300000
     minimum energy value [keV]
-MIN_ENERGY_TO_FIT: 1.0
+MIN_ENERGY_TO_FIT:       1.0000000
     this allows manual adjustment of the branhcing ratios between the different lines of L1, L2, and L3.
     note, the numbers that are put in should be RELATIVE modifications, i.e., a 1 will correspond to exactly the literature value,
     0.8 will correspond to to 80% of that, etc.
 BRANCHING_FAMILY_ADJUSTMENT_L: Pt_L, 0., 1., 1.
 BRANCHING_FAMILY_ADJUSTMENT_L: Gd_L, 1., 1., 1.
-BRANCHING_FAMILY_ADJUSTMENT_L: Sn_L, 0., 0., 1.
-BRANCHING_FAMILY_ADJUSTMENT_L: I_L, 1., 1., 1.
+BRANCHING_FAMILY_ADJUSTMENT_L: Au_L, 0., 1., 1.
+BRANCHING_FAMILY_ADJUSTMENT_L: W_L, 0., 0., 1.
     this allows manual adjustment of the branhcing ratios between the different L lines, such as La 1, la2, etc.
     Please note, these are all RELATIVE RELATIVE modifications, i.e., a 1 will correspond to exactly the literature value, etc.
     all will be normalized to the La1 line, and the values need to be in the following order:
@@ -117,59 +117,34 @@ BRANCHING_RATIO_ADJUSTMENT_K: Ni, 1., 1., 1.05, 1.
 BRANCHING_RATIO_ADJUSTMENT_K: Cu, 1., 1., 1.0, 1.
 BRANCHING_RATIO_ADJUSTMENT_K: Zn, 1., 1., 1.0, 1.
     the parameter adds the escape peaks (offset) to the fit if larger than 0. You should not enable Si and Ge at the same time, ie, one of these two values should be zero
-SI_ESCAPE_FACTOR: 0.0
-GE_ESCAPE_FACTOR: 0.0
+SI_ESCAPE_FACTOR:      0.00000000
+GE_ESCAPE_FACTOR:      0.00000000
     this parameter adds a component to the escape peak that depends linear on energy
-LINEAR_ESCAPE_FACTOR: 0.0
+LINEAR_ESCAPE_FACTOR:      0.00000000
     the parameter enables fitting of the escape peak strengths. set 1 to enable, set to 0 to disable. (in matrix fitting always disabled)
-SI_ESCAPE_ENABLE: 0
-GE_ESCAPE_ENABLE: 0
+SI_ESCAPE_ENABLE:       0
+GE_ESCAPE_ENABLE:       0
     the lines (if any) below will override the detector names built in to maps. please modify only if you are sure you understand the effect
-SRCURRENT: S:SRcurrentAI
-US_IC: 2xfm:scaler3_cts1.B
-DS_IC: 2xfm:scaler3_cts1.C
-DPC1_IC: 2xfm:scaler3_cts2.A
-DPC2_IC: 2xfm:scaler3_cts2.B
-CFG_1: 2xfm:scaler3_cts3.B
-CFG_2: 2xfm:scaler3_cts3.C
-CFG_3: 2xfm:scaler3_cts3.D
-CFG_4: 2xfm:scaler3_cts4.A
-CFG_5: 2xfm:scaler3_cts4.B
-CFG_6: 2xfm:scaler3_cts4.C
-CFG_7: 2xfm:scaler3_cts4.D
-CFG_8: 2xfm:scaler3_cts5.A
-CFG_9: 2xfm:scaler3_cts5.B
-    These scalers are for fly scans.  Tag: Name;PV
-TIME_SCALER_PV: 2xfm:mcs:mca1.VAL
-TIME_SCALER_CLOCK: 25000000.0
-TIME_NORMALIZED_SCALER: US_IC;2xfm:mcs:mca2.VAL
-TIME_NORMALIZED_SCALER: DS_IC;2xfm:mcs:mca3.VAL
-TIME_NORMALIZED_SCALER: DPC1_IC;2xfm:mcs:mca5.VAL
-TIME_NORMALIZED_SCALER: DPC2_IC;2xfm:mcs:mca6.VAL
-TIME_NORMALIZED_SCALER: CFG_1;2xfm:mcs:mca10.VAL
-TIME_NORMALIZED_SCALER: CFG_2;2xfm:mcs:mca11.VAL
-TIME_NORMALIZED_SCALER: CFG_3;2xfm:mcs:mca12.VAL
-TIME_NORMALIZED_SCALER: CFG_4;2xfm:mcs:mca13.VAL
-TIME_NORMALIZED_SCALER: CFG_5;2xfm:mcs:mca14.VAL
-TIME_NORMALIZED_SCALER: CFG_6;2xfm:mcs:mca15.VAL
-TIME_NORMALIZED_SCALER: CFG_7;2xfm:mcs:mca16.VAL
-TIME_NORMALIZED_SCALER: CFG_8;2xfm:mcs:mca17.VAL
-TIME_NORMALIZED_SCALER: CFG_9;2xfm:mcs:mca18.VAL
-    Spectra scalers
-ELT1: dxpXMAP2xfm3:mca4.ELTM
-ERT1: dxpXMAP2xfm3:mca4.ERTM
-ICR1: dxpXMAP2xfm3:dxp1:InputCountRate
-OCR1: dxpXMAP2xfm3:dxp1:OutputCountRate
+SRCURRENT:S:SRcurrentAI
+US_IC:21:D3:scaler1_cts2.B
+	DS_IC:21:D3:scaler1_cts3.A
+CFG_2:21:D3:scaler1_cts1.B
+CFG_3:21:D3:scaler1_cts1.C
+CFG_4:21:D3:scaler1_cts1.D
+CFG_5:21:D3:scaler1_cts2.A
+SUMMED_SCALER:DS_IC:CFG_2,CFG_3,CFG_4,CFG_5
+ELT1:21:D3win:mca1.ELTM
+ERT1:21:D3win:mca1.ERTM
     the lines below (if any) give backup description of IC amplifier sensitivity, in case it cannot be found in the mda file
-		 for the amps, the _NUM value should be between 0 and 8 where 0=1, 1=2, 2=5, 3=10, 4=20, 5=50, 6=100, 7=200, 8=500
-		 for the amps, the _UNIT value should be between 0 and 3 where 0=pa/v, 1=na/v, 2=ua/v 3=ma/v
-    search for the PV first, if not found then use the values below
-US_AMP_SENS_NUM_PV: 2xfm:A1sens_num.VAL
-US_AMP_SENS_UNIT_PV: 2xfm:A1sens_unit.VAL
-DS_AMP_SENS_NUM_PV: 2xfm:A2sens_num.VAL
-DS_AMP_SENS_UNIT_PV: 2xfm:A2sens_unit.VAL
-
-US_AMP_SENS_NUM:        5
-US_AMP_SENS_UNIT:        1
-DS_AMP_SENS_NUM:        1
-DS_AMP_SENS_UNIT:        1
+      for the amps, the _NUM value should be between 0 and 8 where 0=1, 1=2, 2=5, 3=10, 4=20, 5=50, 6=100, 7=200, 8=500
+      for the amps, the _UNIT value should be between 0 and 3 where 0=pa/v, 1=na/v, 2=ua/v 3=ma/v
+    These scalers are for fly scans.  Tag: Name;PV
+TIME_SCALER_PV:21:D3:scaler1:mca1.VAL
+TIME_SCALER_CLOCK:50000000
+TIME_NORMALIZED_SCALER:CFG_2;21:D3:scaler1:mca2.VAL
+TIME_NORMALIZED_SCALER:CFG_3;21:D3:scaler1:mca3.VAL
+TIME_NORMALIZED_SCALER:CFG_4;21:D3:scaler1:mca4.VAL
+TIME_NORMALIZED_SCALER:CFG_5;21:D3:scaler1:mca5.VAL
+TIME_NORMALIZED_SCALER:US_IC;21:D3:scaler1:mca6.VAL
+	TIME_NORMALIZED_SCALER:DS_IC;21:D3:scaler1:mca7.VAL
+TIME_NORMALIZED_SUMMED_SCALER:DS_IC:CFG_2,CFG_3,CFG_4,CFG_5

--- a/src/mvc/FitSpectraWidget.cpp
+++ b/src/mvc/FitSpectraWidget.cpp
@@ -277,7 +277,7 @@ void FitSpectraWidget::on_export_fit_paramters()
     fit_params.append_and_update(&model_fit_params);
     fit_params.append_and_update(&element_fit_params);
 
-    emit export_fit_paramters(fit_params);
+    emit export_fit_paramters(fit_params, element_fit_params);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/src/mvc/FitSpectraWidget.h
+++ b/src/mvc/FitSpectraWidget.h
@@ -69,7 +69,7 @@ signals:
 
    void vertical_element_line_changed(qreal, QString);
 
-   void export_fit_paramters(data_struct::Fit_Parameters fit_params);
+   void export_fit_paramters(data_struct::Fit_Parameters fit_params, data_struct::Fit_Parameters elements_to_fit);
 
 public slots:
 

--- a/src/mvc/MDA_Widget.cpp
+++ b/src/mvc/MDA_Widget.cpp
@@ -139,12 +139,14 @@ void MDA_Widget::model_updated()
 
 /*---------------------------------------------------------------------------*/
 
-void MDA_Widget::on_export_fit_params(data_struct::Fit_Parameters fit_params)
+void MDA_Widget::on_export_fit_params(data_struct::Fit_Parameters fit_params, data_struct::Fit_Parameters elements_to_fit)
 {
     unsigned int det = _cb_detector->currentText().toUInt();
+    data_struct::Params_Override default_po;
     if (_model != nullptr)
     {
-        data_struct::Params_Override* po  = _model->getParamOverrideOrAvg(det);
+        data_struct::Params_Override* po = _model->getParamOverrideOrAvg(det);
+        
         if (po != nullptr)
         {
             QString save_path = _model->getPath();
@@ -153,11 +155,16 @@ void MDA_Widget::on_export_fit_params(data_struct::Fit_Parameters fit_params)
                 save_path.chop(3);
             }
             save_path += "maps_fit_parameters_override.txt" + _cb_detector->currentText();
-            QString fileName = QFileDialog::getSaveFileName(this, "Save parameters override", save_path, "TXT"+ _cb_detector->currentText()+" (*.txt"+ _cb_detector->currentText()+" *.TXT"+_cb_detector->currentText()+")");
+            QString fileName = QFileDialog::getSaveFileName(this, "Save parameters override", save_path, "TXT" + _cb_detector->currentText() + " (*.txt" + _cb_detector->currentText() + " *.TXT" + _cb_detector->currentText() + ")");
             if (!fileName.isEmpty() && !fileName.isNull())
             {
                 data_struct::Fit_Parameters* nfit_params = &(po->fit_params);
                 nfit_params->append_and_update(&fit_params);
+                po->elements_to_fit.clear();
+                for (const auto& itr : elements_to_fit)
+                {
+                    po->elements_to_fit[itr.first] = gen_element_map(itr.first);
+                }
                 if (io::file::aps::save_parameters_override(fileName.toStdString(), po))
                 {
                     QMessageBox::information(nullptr, "Export Fit Parameters", "Saved");

--- a/src/mvc/MDA_Widget.h
+++ b/src/mvc/MDA_Widget.h
@@ -46,7 +46,7 @@ public slots:
 
    //void onScalerSelect(const QString& det);
 
-   void on_export_fit_params(data_struct::Fit_Parameters fit_params);
+   void on_export_fit_params(data_struct::Fit_Parameters fit_params, data_struct::Fit_Parameters elements_to_fit);
 
 protected:
 

--- a/src/mvc/MapsElementsWidget.cpp
+++ b/src/mvc/MapsElementsWidget.cpp
@@ -341,7 +341,7 @@ void MapsElementsWidget::setModel(MapsH5Model* model)
 
 /*---------------------------------------------------------------------------*/
 
-void MapsElementsWidget::on_export_fit_params(data_struct::Fit_Parameters fit_params)
+void MapsElementsWidget::on_export_fit_params(data_struct::Fit_Parameters fit_params, data_struct::Fit_Parameters elements_to_fit)
 {
     if (_model != nullptr)
     {
@@ -378,7 +378,11 @@ void MapsElementsWidget::on_export_fit_params(data_struct::Fit_Parameters fit_pa
             {
                 data_struct::Fit_Parameters* nfit_params = &(param_overrides->fit_params);
                 nfit_params->append_and_update(&fit_params);
-
+                param_overrides->elements_to_fit.clear();
+                for (const auto& itr : elements_to_fit)
+                {
+                    param_overrides->elements_to_fit[itr.first] = gen_element_map(itr.first);
+                }
                 if (io::file::aps::save_parameters_override(fileName.toStdString(), param_overrides))
                 {
                     QMessageBox::information(nullptr, "Export Fit Parameters", "Saved");

--- a/src/mvc/MapsElementsWidget.h
+++ b/src/mvc/MapsElementsWidget.h
@@ -82,7 +82,7 @@ public slots:
 
    void onNewGridLayout(int rows, int cols);
 
-   void on_export_fit_params(data_struct::Fit_Parameters fit_params);
+   void on_export_fit_params(data_struct::Fit_Parameters fit_params, data_struct::Fit_Parameters elements_to_fit);
 
    void onSelectNormalizer(QString name);
 

--- a/src/mvc/RAW_Model.cpp
+++ b/src/mvc/RAW_Model.cpp
@@ -104,7 +104,11 @@ data_struct::Params_Override* RAW_Model::getParamOverride(int idx)
     {
         return _fit_params_override_dict.at(idx);
     }
-    return nullptr;
+	else
+	{
+		_fit_params_override_dict[idx] = new data_struct::Params_Override();
+		return _fit_params_override_dict.at(idx);
+	}
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
…if override file is missing, you can still export and make one.